### PR TITLE
Add install statement for newer versions of go

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ A tool to convert images saved from `docker save` to [oci format image](https://
 
 ## Installation
 
+For go up to version 1.17, use:
+
 ```
 go get github.com/coolljt0725/docker2oci
+```
+
+For go version 1.17+, use:
+
+```
+go install github.com/coolljt0725/docker2oci@latest
 ```
 
 ## Build


### PR DESCRIPTION
Starting with go 1.17 [1], the command `go get` informs that:
> 'go get' is no longer supported outside a module.

Instead, the following command may be used to install commands: 

```
go install github.com/coolljt0725/docker2oci@latest
```

This PR changes the README.md to reflect this change.

[1] https://go.dev/doc/go-get-install-deprecation